### PR TITLE
(untested) Display Receiving party

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koder-react",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "homepage": "./",
   "private": true,
   "devDependencies": {

--- a/src/transformers/upnqr.js
+++ b/src/transformers/upnqr.js
@@ -46,6 +46,7 @@ class Upnqr {
     if (rok.length > 0) res += `Rok plačila: ${rok}\n`;
     if (obj.IBAN_prejemnika != null) res += `IBAN: ${obj.IBAN_prejemnika}\n`;
     if (obj.nujno != null) res += `Nujno: ${obj.nujno ? "da" : "ne"}\n\n`;
+    if (obj.ime_prejemnika != null) res += `Prejemnik: ${obj.ime_prejemnika}\n`;
     if (obj.referenca_prejemnika != null) res += `Referenca: ${obj.referenca_prejemnika}\n`;
     if (obj.ulica_prejemnika != null) res += `Naslov: ${obj.ulica_prejemnika}\n`;
     if (obj.kraj_prejemnika != null) res += `Kraj: ${obj.kraj_prejemnika}`;


### PR DESCRIPTION
Add a name of the receiving party.

USE CASE:
If you don't have a receiving party in Revolut Bank use the name for addition to the list.
I understand it could also be copied from RAW format.